### PR TITLE
Added wrapper script and made some changes

### DIFF
--- a/CompuCell3D Sorting/extractcellfeatures.py
+++ b/CompuCell3D Sorting/extractcellfeatures.py
@@ -9,6 +9,7 @@ import scipy.special
 import skimage.measure
 import skimage.morphology
 import perimeter_3pvm
+import matplotlib.pyplot as PLT
 
 from operator import itemgetter
 from scipy import interpolate
@@ -64,10 +65,12 @@ class ExtractFeatures:
 
 		# Find the pixels that make up the perimeter
 		eroded_image = NDI.binary_erosion(self.cell_img)
-		eroded_image2 = NDI.binary_erosion(eroded_image)
+
+		eroded_image_open = NDI.binary_opening(eroded_image, structure=NP.ones((3,3)))
+		eroded_image_open2 = NDI.binary_erosion(eroded_image_open)
 
 		# self.perim_img = self.cell_img - eroded_image
-		self.eroded_img = eroded_image - eroded_image2
+		self.eroded_img = eroded_image_open - eroded_image_open2
 		self.perim_img = self.cell_img - eroded_image
 
 		# Create a list of the coordinates of the pixels (use the center of the pixels)

--- a/CompuCell3D Sorting/pif_extract_features_wrapper.py
+++ b/CompuCell3D Sorting/pif_extract_features_wrapper.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+
+#
+# Last modified: 26 May 2016
+# Author: Darrick Lee <y.l.darrick@gmail.com>, Dhananjay Bhaskar <dbhaskar92@gmail.com>
+# A wrapper for pif_extract_features.py to execute for a set of PIF files.
+# 
+
+import os
+import glob
+import time
+import threading
+import subprocess
+import numpy as NP
+from optparse import OptionParser
+
+
+pifFolder = ''
+startTime, endTime = None, None
+threads = 1
+
+parser = OptionParser()
+parser.add_option("-p", "--path", action="store", type="string", dest="pifFolder", help="path to folder with PIF files", metavar="PIF")
+parser.add_option("--start", action="store", type="int", dest="start", help="first time to process", metavar="START")
+parser.add_option("--end", action="store", type="int", dest="end", help="last time to process", metavar="END")
+parser.add_option('-t', "--threads", action="store", type="int", dest="threads", help="number of threads to run", metavar="THREAD")
+
+# Options parsing
+(options, args) = parser.parse_args()
+if options.pifFolder:
+	pifFolder = options.pifFolder
+if options.start is not None:
+	startTime = options.start
+else:
+	startTime = 0
+if options.end is not None:
+	endTime = options.end
+else:
+	endTime = 9999999
+if options.threads:
+	threads = options.threads
+
+def run_pif_extract_features(pifList):
+	# Function that executes pif_extract_features.py for all given pif files
+	for pif in pifList:
+		pifName = os.path.splitext(pif)[0]
+
+		subprocess.call(['python', 'pif_extract_features.py',
+			'-i', pif,
+			'-o', pifFolder,
+			'-l', '800',
+			'-w', '800',
+			'-p', '-s'])
+
+t0 = time.time()
+
+# Create a list of all pif file names
+if pifFolder:
+	if os.path.isdir(pifFolder):
+		allPif = glob.glob(pifFolder + '*.pif')
+	else:
+		print("Error: Directory does not exist.\n")
+		exit()
+else:
+	allPif = glob.glob('*.pif')
+
+# Create equal partitions of allPif for each thread
+numPif_total = len(allPif)
+if endTime > numPif_total:
+	endTime = numPif_total
+
+numPif = endTime - startTime
+
+allPif = NP.array(allPif)
+pifPartition = dict()
+allPifNum = NP.array([int(pif.split('/')[-1].split('.')[0]) for pif in allPif])
+
+for i in range(threads):
+	part_startTime = startTime + i*numPif/(threads)
+	part_endTime = startTime + (i+1)*numPif/(threads)
+
+	inRange = (allPifNum >= part_startTime) * (allPifNum < part_endTime)
+	pifPartition[i] = list(allPif[inRange])
+
+# Split the job up into the given number of threads
+thread_list = []
+
+for partNum in pifPartition:
+	thread_list.append(threading.Thread(target=run_pif_extract_features, args=(pifPartition[partNum],)))
+
+for thread in thread_list:
+	thread.start()
+
+for thread in thread_list:
+	thread.join()
+
+t1 = time.time()
+
+print("Total runtime is {0} seconds.").format(t1-t0)
+
+


### PR DESCRIPTION
Added wrapper script
- Includes multithreading

Changes in pif_extract_features.py:
- We can now input a path to a pif file (ex. -i pifFiles/0001.pif) rather than just the path name
- Added option (-o) for the output path for the generated images
- Added option (-s) to separate the plots into different folders in the output path
- Added option (-m) for multithreading when calling the extractor methods. The default is no multithreading because I added parallelization to the wrapper script. I decided to put it there because we know that running pif_extract_features.py will take roughly the same amount of time for each cell, whereas basic_props(), ellipse_props(), and cell_centre_fit() probably take different amounts of time, so we spend more time waiting.

Changes in extractcellfeatures.py:
- Fixed a bug dealing with the eroded perimeter. It was possible to get an eroded perimeter with isolated points, which could potentially mess up the 3pv perimeter algorithm. This was fixed by applying a binary opening to the eroded image first - this essentially smooths the eroded perimeter, which is fine because that is what it is supposed to represent anyways.

Known bug:
- Circle fit fails for cases where the cell crosses the lattice boundary and appears on the other side (since it seems there are periodic boundaries). Half of the cell appears on one side of the boundary, and half on the other - compare the circle fit and the original image (note the cells at the top and bottom).
  ![5301_circlefit](https://cloud.githubusercontent.com/assets/5273395/15601454/4b67f318-23a4-11e6-8344-365d14195e80.png)

![5301_boundary](https://cloud.githubusercontent.com/assets/5273395/15601491/81bc5936-23a4-11e6-882d-8f303e354fa1.png)
